### PR TITLE
esc_url for add_query_arg

### DIFF
--- a/lib/TwitterWP.php
+++ b/lib/TwitterWP.php
@@ -496,7 +496,7 @@ class TwitterWP {
 		$this->base_url = $this->url . $trail;
 
 		// append query args
-		return !empty( $params ) ? add_query_arg( $params, $this->base_url ) : $this->base_url;
+		return !empty( $params ) ? esc_url( add_query_arg( $params, $this->base_url ) ) : $this->base_url;
 	}
 
 	/**


### PR DESCRIPTION
Some changes (or clarifications) in the usage of add_query_args: https://make.wordpress.org/plugins/2015/04/20/fixing-add_query_arg-and-remove_query_arg-usage/